### PR TITLE
markdowndocs: fix skipping unwanted directories...

### DIFF
--- a/src/tfwebserver/markdowndocs.cr
+++ b/src/tfwebserver/markdowndocs.cr
@@ -4,6 +4,8 @@ require "file_utils"
 
 module TFWeb
   class MarkdownDocs
+    include Utils::FS
+
     property dirfilesinfo
     property docspath = ""
 
@@ -129,9 +131,7 @@ module TFWeb
       @errors = Hash(String, String).new # reset errors.
 
       @dirfilesinfo = Hash(String, TFWeb::FInfoTracker).new # reset.
-      Dir.glob("#{path}/**/*") do |thepath|
-        next if should_skip?(thepath)
-
+      walk_files(path, @skips) do |thepath|
         child = File.basename(thepath)
         # next if child.starts_with?("_")
         if !@dirfilesinfo.has_key?(child.to_s)
@@ -157,10 +157,8 @@ module TFWeb
     # walk over filesystem to buildup the fixer
     private def _fix(path)
       seen = Array(String).new
-      Dir.glob("#{path}/**/*") do |thepath|
-        next if should_skip?(thepath) || thepath.downcase == "#{docspath}/readme.md"
-        next if seen.includes?(thepath)
-        seen << thepath.to_s
+      walk_files(path, @skips) do |thepath|
+        next if thepath.downcase == "#{docspath}/readme.md"
 
         path_obj = Path.new(thepath)
         next if path_obj.basename.starts_with?("_")

--- a/src/tfwebserver/markdowndocs.cr
+++ b/src/tfwebserver/markdowndocs.cr
@@ -95,11 +95,20 @@ module TFWeb
     end
 
     private def should_skip?(path)
+      # skip path if a directory or
+      if Dir.exists?(path)
+        return true
+      end
+
+      # check if parent directory in @skips
+      dirname = File.basename(File.dirname(path))
       @skips.each do |skipped|
-        if path.includes?(skipped)
+        if dirname.downcase.strip == skipped
+          Logger.debug { "skipping file: #{path}..." }
           return true
         end
       end
+
       return false
     end
 
@@ -121,7 +130,7 @@ module TFWeb
 
       @dirfilesinfo = Hash(String, TFWeb::FInfoTracker).new # reset.
       Dir.glob("#{path}/**/*") do |thepath|
-        next if Dir.exists?(thepath) || should_skip?(thepath)
+        next if should_skip?(thepath)
 
         child = File.basename(thepath)
         # next if child.starts_with?("_")

--- a/src/tfwebserver/markdowndocs.cr
+++ b/src/tfwebserver/markdowndocs.cr
@@ -96,24 +96,6 @@ module TFWeb
       @dirfilesinfo["errors.md"] = ferrors
     end
 
-    private def should_skip?(path)
-      # skip path if a directory or
-      if Dir.exists?(path)
-        return true
-      end
-
-      # check if parent directory in @skips
-      dirname = File.basename(File.dirname(path))
-      @skips.each do |skipped|
-        if dirname.downcase.strip == skipped
-          Logger.debug { "skipping file: #{path}..." }
-          return true
-        end
-      end
-
-      return false
-    end
-
     private def cp_r2(src_path : String, dest_path : String)
       if Dir.exists?(src_path)
         Dir.mkdir(dest_path) unless Dir.exists?(dest_path)

--- a/src/tfwebserver/utils/fs.cr
+++ b/src/tfwebserver/utils/fs.cr
@@ -18,6 +18,22 @@ module TFWeb
           end
         end
       end
+
+      def walk_files(root, skips = [] of String, &block : String ->)
+        Dir.each_child(root) do |entry|
+          if skips.includes?(entry.strip.downcase)
+            Logger.debug { "skipping '#{entry}' at '#{root}'" }
+            next
+          end
+
+          path = File.join(root, entry)
+          if File.directory?(path)
+            walk_files(path, &block)
+          else
+            yield path
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
it was skipping files too, and walking files instead of using glob to properly skip unwanted directories.